### PR TITLE
feat: can reconnect

### DIFF
--- a/odrive_base/include/socket_can.hpp
+++ b/odrive_base/include/socket_can.hpp
@@ -16,6 +16,9 @@ public:
     bool send_can_frame(const can_frame& frame);
 
     bool read_nonblocking();
+
+    void reset_can_connection_check();
+    bool has_can_reconnected();
 private:
     std::string interface_;
     int socket_id_ = -1;
@@ -23,6 +26,8 @@ private:
     EpollEventLoop::EvtId socket_evt_id_;
     FrameProcessor frame_processor_;
     bool broken_ = false;
+    bool can_send_failed_ = false;
+    bool has_been_can_send_failed_ = false;
 
     void on_socket_event(uint32_t mask);
     void process_can_frame(const can_frame& frame) {

--- a/odrive_base/src/socket_can.cpp
+++ b/odrive_base/src/socket_can.cpp
@@ -78,8 +78,11 @@ bool SocketCanIntf::send_can_frame(const can_frame& frame) {
     ssize_t nbytes = write(socket_id_, &frame, sizeof(frame));
     if (nbytes == -1) {
         std::cerr << "Failed to send CAN frame" << std::endl;
+        can_send_failed_ = true;
+        has_been_can_send_failed_ = true;
         return false;
     }
+    can_send_failed_ = false;
 
     return true;
 }
@@ -134,4 +137,12 @@ bool SocketCanIntf::read_nonblocking() {
 
     process_can_frame(frame);
     return true;
+}
+
+void SocketCanIntf::reset_can_connection_check() {
+    has_been_can_send_failed_ = false;
+}
+
+bool SocketCanIntf::has_can_reconnected() {
+    return can_send_failed_ == false && has_been_can_send_failed_ == true;
 }

--- a/odrive_botwheel_explorer/description/urdf/diffbot.ros2_control.xacro
+++ b/odrive_botwheel_explorer/description/urdf/diffbot.ros2_control.xacro
@@ -8,6 +8,7 @@
         <hardware>
           <plugin>odrive_ros2_control_plugin/ODriveHardwareInterface</plugin>
           <param name="can">can0</param>
+          <param name="can_reconnect">false</param>
         </hardware>
       </xacro:unless>
       <xacro:if value="${use_mock_hardware}">


### PR DESCRIPTION
Hello,
I’ve been playing around with the BotWheel Explorer I purchased.

There’s something I noticed—when the emergency stop switch is pressed, the CAN connection gets cut off.
As a result, even if I send speed commands to the motors, there’s no response, which I found a bit frustrating. So I modified the code so that the motors will still respond to speed commands even after the CAN connection is reestablished.

You can choose whether or not to use this feature through a parameter setting.
` <param name="can_reconnect">true</param>`

I think this feature is quite useful.
I’ve confirmed that it works with the BotWheel Explorer!
If you find any issues, please let me know.