### PR TITLE
Add E-stop service to send estop CAN frames

### DIFF
--- a/odrive_node/README.md
+++ b/odrive_node/README.md
@@ -60,6 +60,12 @@ For information about installation, prerequisites and getting started, check out
   If the axis dropped into IDLE because of an error and the intent is to re-enable it, call `/request_axis_state`
   instead with CLOSED_LOOP_CONTROL, which clears errors automatically.
 
+* `/estop`: Emergency stop service that immediately disarms the axis.
+
+  This service sends an empty payload CAN frame that causes the ODrive axis to enter IDLE state with "ESTOP_REQUESTED" as the disarm reason. The service call completes immediately without waiting for confirmation from the ODrive.
+
+  This is intended for emergency situations where the motor needs to be stopped as quickly as possible. After an estop, the axis will need to be re-enabled using `/request_axis_state` with the desired state, which will automatically clear the estop error (See `/request_axis_state` above).
+
 ### Data Types
 
 All of the Message/Service fields are directly related to their corresponding CAN message. For more detailed information about each type, and how to interpet the data, please refer to the [ODrive CAN protocol documentation](https://docs.odriverobotics.com/v/latest/manual/can-protocol.html#messages).

--- a/odrive_node/include/odrive_can_node.hpp
+++ b/odrive_node/include/odrive_can_node.hpp
@@ -36,8 +36,10 @@ private:
     void subscriber_callback(const ControlMessage::SharedPtr msg);
     void service_callback(const std::shared_ptr<AxisState::Request> request, std::shared_ptr<AxisState::Response> response);
     void service_clear_errors_callback(const std::shared_ptr<Empty::Request> request, std::shared_ptr<Empty::Response> response);
+    void service_estop_callback(const std::shared_ptr<Empty::Request> request, std::shared_ptr<Empty::Response> response);
     void request_state_callback();
     void request_clear_errors_callback();
+    void request_estop_callback();
     void ctrl_msg_callback();
     inline bool verify_length(const std::string&name, uint8_t expected, uint8_t length);
     
@@ -68,6 +70,9 @@ private:
 
     EpollEvent srv_clear_errors_evt_;
     rclcpp::Service<Empty>::SharedPtr service_clear_errors_;
+
+    EpollEvent srv_estop_evt_;
+    rclcpp::Service<Empty>::SharedPtr service_estop_;
 
 };
 


### PR DESCRIPTION
Add a service to allow sending of the Estop CAN message upon request per the CAN message spec:

https://docs.odriverobotics.com/v/latest/manual/can-protocol.html#estop

This has been fully integration tested and shown to consistently estop the motors within a full ROS2 stack with several odrive_can nodes