### PR TITLE
Set open_loop to false by default in diffbot_controllers

### DIFF
--- a/odrive_botwheel_explorer/config/diffbot_controllers.yaml
+++ b/odrive_botwheel_explorer/config/diffbot_controllers.yaml
@@ -26,7 +26,7 @@ botwheel_explorer:
     pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
     twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 
-    open_loop: true
+    open_loop: false
     enable_odom_tf: true
 
     cmd_vel_timeout: 0.5


### PR DESCRIPTION
Self explanatory. 

Will use actual encoder messages for odometry instead of commanded velocity.