### PR TITLE
Drop unknown exports

### DIFF
--- a/odrive_node/package.xml
+++ b/odrive_node/package.xml
@@ -20,12 +20,10 @@
 
   <exec_depend>ament_cmake</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  
+
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
-    <rosidl_package_name>${PROJECT_NAME}</rosidl_package_name>
-    <rosidl_target_interfaces>msg/${PROJECT_NAME}.msg</rosidl_target_interfaces>
     <build_type>ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
Odrive is the only ones using this syntax is seems: 

https://github.com/search?q=rosidl_target_interfaces%20path%3A**%2Fpackage.xml&type=code