### PR TITLE
Bugfix: Remove ament_target_dependencies calls from CMakeLists.txt files

### DIFF
--- a/odrive_node/CMakeLists.txt
+++ b/odrive_node/CMakeLists.txt
@@ -29,11 +29,6 @@ add_executable(odrive_can_node
   src/main.cpp
   include/odrive_can_node.hpp)
 
-ament_target_dependencies(odrive_can_node
-  rclcpp
-  std_srvs
-)
-
 target_compile_features(odrive_can_node PRIVATE cxx_std_20)
 
 install(
@@ -48,6 +43,9 @@ install(DIRECTORY launch
 rosidl_get_typesupport_target(cpp_typesupport_target
   ${PROJECT_NAME} rosidl_typesupport_cpp)
 
-target_link_libraries(odrive_can_node "${cpp_typesupport_target}")
+target_link_libraries(odrive_can_node
+	rclcpp::rclcpp
+	std_srvs::std_srvs
+	"${cpp_typesupport_target}")
 
 ament_package()

--- a/odrive_ros2_control/CMakeLists.txt
+++ b/odrive_ros2_control/CMakeLists.txt
@@ -23,9 +23,8 @@ ament_auto_add_library(
   src/odrive_hardware_interface.cpp
 )
 
-ament_target_dependencies(odrive_ros2_control_plugin
-  rclcpp
-)
+target_link_libraries(odrive_ros2_control_plugin
+	rclcpp)
 
 pluginlib_export_plugin_description_file(hardware_interface odrive_hardware_interface.xml)
 


### PR DESCRIPTION
`ament_target_dependencies()` has been deprecated since Kilted, and has been removed from Lyrical entirely, causing builds to fail. Remove all `ament_target_dependencies()` calls and use `target_link_libraries()` with modern CMake target specifiers instead.

For the curious, [this](https://discourse.openrobotics.org/t/best-practices-for-replacing-ament-target-dependencies-in-kilted-while-maintaining-compatibility/43938/4) thread discusses why the change was made and why `target_link_libraries` is functionally equivalent.

I couldn't find any explicit mention of Lyrical support (README just indicates '>=Humble'), but this has been my only problem so far.